### PR TITLE
Fix crash from deleted service ID

### DIFF
--- a/path_creds.go
+++ b/path_creds.go
@@ -159,6 +159,9 @@ func (b *ibmCloudSecretBackend) getSecretKey(ctx context.Context, s logical.Stor
 		if err != nil {
 			return nil, err
 		}
+		if resp.IsError() {
+			return resp, nil
+		}
 	} else {
 		return logical.ErrorResponse("role %s has neither access groups nor a service ID", roleName), nil
 	}


### PR DESCRIPTION
Fix a nil pointer issue which occurs from the following
steps, and other errors that can come from validating
service IDs during API key/credential generation:

1. create a role with a service ID.
2. delete the service ID from IBM Cloud
3. attempt a key create using the role

Fixes: #5