### PR TITLE
Address 'go get' install of modules

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/publish_release_on_tag.yml
+++ b/.github/workflows/publish_release_on_tag.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
         id: go
 
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ generate:
 bootstrap:
 	@for tool in  $(EXTERNAL_TOOLS) ; do \
 		echo "Installing/Updating $$tool" ; \
-		go get -u $$tool; \
+		go install $$tool; \
 	done
 
 fmtcheck:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module vault-plugin-secrets-ibmcloud
 
-go 1.14
+go 1.16
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible


### PR DESCRIPTION
Change the module build to use "go install" to install dependencies
rather than 'go get'. Using 'go get' to install modules has been
deprecated since Go 1.16 and now that Go 1.18 is released the
build of this module no longer works.

While updating the Makefile to use "go install", we also update
 the module and github workflows to require a Go 1.16 minimum
level.