### PR TITLE
Default the IAM endpoint on config read

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -132,6 +132,10 @@ func (b *ibmCloudSecretBackend) pathConfigRead(ctx context.Context, req *logical
 		displayKey = redacted
 	}
 
+	if config.IAMEndpoint == "" {
+		config.IAMEndpoint = iamEndpointFieldDefault
+	}
+
 	resp := &logical.Response{
 		Data: map[string]interface{}{
 			apiKeyField:      displayKey,
@@ -164,6 +168,9 @@ func (b *ibmCloudSecretBackend) getConfig(ctx context.Context, s logical.Storage
 	}
 	if config.Account == "" {
 		return nil, logical.ErrorResponse("no account ID was set in the configuration")
+	}
+	if config.IAMEndpoint == "" {
+		config.IAMEndpoint = iamEndpointFieldDefault
 	}
 
 	return config, nil

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -152,7 +152,7 @@ func testConfigCreate(t *testing.T, b *ibmCloudSecretBackend, s logical.Storage,
 func TestLoadOfPreviousConfig(t *testing.T) {
 	b, s := testBackend(t)
 
-	// set config without endpoint defaults set, mimicing a v0.1.0 config
+	// set config without endpoint defaults set, mimicking a v0.1.0 config
 	config, err := b.config(context.Background(), s)
 	if err != nil {
 		t.Fatal(err)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -148,3 +148,36 @@ func testConfigCreate(t *testing.T, b *ibmCloudSecretBackend, s logical.Storage,
 	}
 	return nil
 }
+
+func TestLoadOfPreviousConfig(t *testing.T) {
+	b, s := testBackend(t)
+
+	// set config without endpoint defaults set, mimicing a v0.1.0 config
+	config, err := b.config(context.Background(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config == nil {
+		config = new(ibmCloudConfig)
+	}
+	config.APIKey = "key"
+	config.Account = "account"
+
+	entry, err := logical.StorageEntryJSON("config", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Put(context.Background(), entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load the config and verify the endpoints are defaulted
+	newConfig, resp := b.getConfig(context.Background(), s)
+	if resp != nil {
+		t.Fatal(resp.Error())
+	}
+
+	if newConfig.IAMEndpoint != iamEndpointFieldDefault {
+		t.Fatalf("The config's IAM Endpoint was not defaulted correctly on the load of a previous version config")
+	}
+}

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -152,7 +152,7 @@ func testConfigCreate(t *testing.T, b *ibmCloudSecretBackend, s logical.Storage,
 func TestLoadOfPreviousConfig(t *testing.T) {
 	b, s := testBackend(t)
 
-	// set config without endpoint defaults set, mimicking a v0.1.0 config
+	// set config without endpoint default set, mimicking a v0.1.0 config
 	config, err := b.config(context.Background(), s)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Default the endpoint on configuration reads
so the current plugin will work with configurations
stored by v0.1.0.
